### PR TITLE
Python 3 compatibility and migration to config.conf

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,0 +1,20 @@
+import re
+import os
+import config
+import globalVars
+
+def onInstall():
+	oldOCRConfig = os.path.join(globalVars.appArgs.configPath, "ocr.ini")
+	try:
+		with open(oldOCRConfig, "r", encoding = "utf-8") as f:
+			configContent = f.read()
+		langFinder = r'^language \= (.+)$'
+		if re.match(langFinder, configContent):
+			OCRLang = re.match(langFinder, configContent)[1]
+			# Ensure that language is written to the default configuration
+			if "ocr" not in config.conf.profiles[0]:
+				config.conf.profiles[0]["ocr"] = {}
+			config.conf.profiles[0]["ocr"]["language"] = OCRLang
+		os.remove(oldOCRConfig)
+	except FileNotFoundError:
+		pass


### PR DESCRIPTION
Closes #6 
closes #2 
Related to https://github.com/nvaccess/nvda/issues/6093
Related to https://github.com/nvaccess/nvda/issues/2599

## Description of the problem:
In Python 3 versions of NVDA there were two  problems preventing OCR add-on from working:
- The Python 3 Pillow requires pathlib which  is not bundled with NVDA.
- Importing validate directly is now deprecated.

## Description of the fix:
- The directory containing plugin is temporarily added to PYTHONPATH when importing Pillow. To make this work it is required to place pathlib from PythonInstallDir\lib in the globalPlugins\ocr folder prior to building the add-on
- The configuration is no longer stored in a separate file but is managed by config.conf. For people  with old config it is migrated during add-on installation.
While at it I've also moved OCR settings to the NVDA's settings dialog - this allows different recognition languages for different profiles.